### PR TITLE
Renaming and Optimization

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Contract Compiling, Testing, and Formatting
 
 on:
   push:

--- a/.github/workflows/fiducia_app_publish.yml
+++ b/.github/workflows/fiducia_app_publish.yml
@@ -1,0 +1,59 @@
+name: Fiducia Safe App to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: "fiducia-app/package-lock.json"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Install dependencies
+        working-directory: fiducia-app
+        run: npm ci
+      - name: Build
+        working-directory: fiducia-app
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: fiducia-app/dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/fiducia-app/README.md
+++ b/fiducia-app/README.md
@@ -5,6 +5,7 @@ A React-based Safe app for managing the Fiducia protocol - a transaction guard a
 ## Overview
 
 Fiducia is a security layer for Safe wallets that allows users to:
+
 - Set up transaction guards with time-delayed activation
 - Configure allowed transactions and token transfers
 - Establish cosigners for additional security
@@ -13,7 +14,7 @@ Fiducia is a security layer for Safe wallets that allows users to:
 ## Features
 
 - **Transaction Guards**: Configure which transactions are allowed
-- **Token Transfer Controls**: Set limits on token transfers to specific recipients  
+- **Token Transfer Controls**: Set limits on token transfers to specific recipients
 - **Cosigner Management**: Add additional signers for transactions
 - **Time-Delayed Activation**: All security changes have time delays before becoming active
 - **Guard Removal**: Securely remove guards with time delays
@@ -27,7 +28,7 @@ Fiducia is a security layer for Safe wallets that allows users to:
 
 ### Prerequisites
 
-- Node.js 18+ 
+- Node.js 18+
 - npm or yarn
 
 ### Setup

--- a/fiducia-app/src/constants.ts
+++ b/fiducia-app/src/constants.ts
@@ -13,12 +13,12 @@ import { ethers } from 'ethers'
 
 /** Fiducia contract address on Sepolia testnet */
 export const FIDUCIA_ADDRESS_SEPOLIA = ethers.getAddress(
-  '0x7bdc54da3dfe4675a43048b3bb2e5cd7fa809283'
+  '0x016a4389ac2c9c2468f98f598e1129a697207312'
 )
 
 /** Fiducia contract address on Gnosis Chain */
 export const FIDUCIA_ADDRESS_GNOSIS = ethers.getAddress(
-  '0x7bdc54da3dfe4675a43048b3bb2e5cd7fa809283'
+  '0x016a4389ac2c9c2468f98f598e1129a697207312'
 )
 
 /** Safe MultiSendCallOnly contract address */
@@ -55,16 +55,16 @@ export const CONTRACT_INTERFACE_ABI = [
   'function scheduleGuardRemoval() public',
   'function setAllowedTx(address to, bytes4 selector, uint8 operation, bool reset) public',
   'function setCosigner(address cosigner, bool reset) public',
-  'function setAllowedTokenTransfer(address token, address to, uint256 maxAmount, bool reset) public',
+  'function setAllowedTokenTransfer(address token, address recipient, uint256 amount, bool reset) public',
 
   // Fiducia View Functions
   'function getTxIdentifierInfo(bytes32 txIdentifier) external view returns (tuple(address to, bytes4 selector, uint8 operation) memory)',
   'function getTxIdentifiers(address account) external view returns (bytes32[] memory)',
-  'function getTokenIdentifierInfo(bytes32 tokenId) external view returns (tuple(address to, address recipient) memory)',
+  'function getTokenIdentifierInfo(bytes32 tokenId) external view returns (tuple(address token, address recipient) memory)',
   'function getTokenIdentifiers(address account) external view returns (bytes32[] memory)',
   'function allowedTxs(address safe, bytes32 txIdentifier) public view returns (uint256 timestamp)',
-  'function allowedTokenTransferInfos(address safe, bytes32 tokenIdentifier) public view returns (tuple(uint256 activeFrom, uint256 maxAmount) memory)',
-  'function cosignerInfos(address safe) public view returns (tuple(uint256 allowedTimestamp, address cosigner) memory)',
+  'function allowedTokenTransferInfos(address safe, address token, address recipient) public view returns (tuple(uint256 activeFrom, uint256 amount) memory)',
+  'function cosignerInfos(address safe) public view returns (tuple(uint256 activeFrom, address cosigner) memory)',
 
   // Other Functions
   'function multiSend(bytes memory transactions) public payable',

--- a/fiducia-app/src/types.ts
+++ b/fiducia-app/src/types.ts
@@ -34,8 +34,8 @@ export interface SetAllowedTokenTransferFormData {
   tokenAddress: string
   /** Address of the allowed recipient */
   recipientAddress: string
-  /** Maximum amount that can be transferred */
-  maxAmount: bigint
+  /** Amount that can be transferred */
+  amount: bigint
   /** Whether to reset/remove the allowance instead of adding it */
   reset: boolean
 }
@@ -51,7 +51,7 @@ export interface AllowedTxInfo {
   /** Operation type as string */
   operation: string
   /** Timestamp when the allowance becomes active (in milliseconds) */
-  allowedTimestamp: bigint
+  activeFrom: bigint
 }
 
 /**
@@ -62,10 +62,10 @@ export interface AllowedTokenTransferInfo {
   token: string
   /** Recipient address */
   recipient: string
-  /** Maximum allowed amount */
-  maxAmount: bigint
+  /** Allowed amount */
+  amount: bigint
   /** Timestamp when the allowance becomes active (in milliseconds) */
-  allowedTimestamp: bigint
+  activeFrom: bigint
 }
 
 /**
@@ -75,5 +75,5 @@ export interface CosignerInfo {
   /** Cosigner address */
   cosigner: string
   /** Timestamp when the cosigner becomes active (in milliseconds) */
-  allowedTimestamp: bigint
+  activeFrom: bigint
 }

--- a/test/Fiducia.t.sol
+++ b/test/Fiducia.t.sol
@@ -509,9 +509,8 @@ contract FiduciaTest is Test {
         emit Fiducia.TokenTransferAllowed(address(safe), address(testToken), recipient, maxAmount, block.timestamp);
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, false);
 
-        bytes32 tokenId =
-            keccak256(abi.encode(address(testToken), recipient, testToken.transfer.selector, Enum.Operation.Call));
-        (uint256 activeFrom, uint256 storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (uint256 activeFrom, uint256 storedMaxAmount) =
+            fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         assertEq(activeFrom, block.timestamp);
         assertEq(storedMaxAmount, maxAmount);
     }
@@ -530,9 +529,8 @@ contract FiduciaTest is Test {
         );
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, false);
 
-        bytes32 tokenId =
-            keccak256(abi.encode(address(testToken), recipient, testToken.transfer.selector, Enum.Operation.Call));
-        (uint256 activeFrom, uint256 storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (uint256 activeFrom, uint256 storedMaxAmount) =
+            fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         assertEq(activeFrom, block.timestamp + DELAY);
         assertEq(storedMaxAmount, maxAmount);
     }
@@ -827,9 +825,8 @@ contract FiduciaTest is Test {
         vm.prank(address(safe));
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, false);
 
-        bytes32 tokenId =
-            keccak256(abi.encode(address(testToken), recipient, testToken.transfer.selector, Enum.Operation.Call));
-        (uint256 activeFrom, uint256 storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (uint256 activeFrom, uint256 storedMaxAmount) =
+            fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         // Verify it was set with current timestamp
         assertEq(activeFrom, block.timestamp);
         assertEq(storedMaxAmount, maxAmount);
@@ -840,7 +837,7 @@ contract FiduciaTest is Test {
         emit Fiducia.TokenTransferAllowed(address(safe), address(testToken), recipient, maxAmount, 0);
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, true);
 
-        (activeFrom, storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (activeFrom, storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         // Verify it was reset to 0 but amount remains
         assertEq(activeFrom, 0);
         assertEq(storedMaxAmount, maxAmount);
@@ -857,9 +854,8 @@ contract FiduciaTest is Test {
         vm.prank(address(safe));
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, false);
 
-        bytes32 tokenId =
-            keccak256(abi.encode(address(testToken), recipient, testToken.transfer.selector, Enum.Operation.Call));
-        (uint256 activeFrom, uint256 storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (uint256 activeFrom, uint256 storedMaxAmount) =
+            fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         // Verify it was set with delay
         assertEq(activeFrom, block.timestamp + DELAY);
         assertEq(storedMaxAmount, maxAmount);
@@ -870,7 +866,7 @@ contract FiduciaTest is Test {
         emit Fiducia.TokenTransferAllowed(address(safe), address(testToken), recipient, maxAmount, 0);
         fiducia.setAllowedTokenTransfer(address(testToken), recipient, maxAmount, true);
 
-        (activeFrom, storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), tokenId);
+        (activeFrom, storedMaxAmount) = fiducia.allowedTokenTransferInfos(address(safe), address(testToken), recipient);
         // Verify it was reset to 0 but amount remains
         assertEq(activeFrom, 0);
         assertEq(storedMaxAmount, maxAmount);


### PR DESCRIPTION
## TLDR
- Naming updation for consistency
- Using `token` and `recipient` within the mapping itself, and ensuring the selector is always for `transfer` and `operation` is always `CALL` for optimization
- Related changes for the Safe App as well
- Also added new workflow for Github pages and updated the workflow name.

## LLM Description
This pull request introduces significant updates to the Fiducia app and smart contract to improve functionality, simplify data structures, and align naming conventions. The most notable changes include replacing `maxAmount` with `amount` for token transfers, renaming `allowedTimestamp` to `activeFrom` for clarity, and updating the contract's mappings and function interfaces accordingly. These updates affect both the frontend and the smart contract code.

### Frontend Updates:

* **Token Transfer Updates:**
  - Replaced `maxAmount` with `amount` in the `SetAllowedTokenTransferFormData`, `AllowedTokenTransferInfo`, and related UI elements (`fiducia-app/src/App.tsx`, `fiducia-app/src/types.ts`). [[1]](diffhunk://#diff-994b961880b30fb5a53fee7411c39b5585f96c630350a02edfb3c7310071cc56L453-R474) [[2]](diffhunk://#diff-994b961880b30fb5a53fee7411c39b5585f96c630350a02edfb3c7310071cc56L909-R933) [[3]](diffhunk://#diff-0ca419857a83516e525de706007d796a8ab7d023c59f9de09a980698ee5bc20dL37-R38) [[4]](diffhunk://#diff-0ca419857a83516e525de706007d796a8ab7d023c59f9de09a980698ee5bc20dL65-R68)

* **Timestamp Field Renaming:**
  - Renamed `allowedTimestamp` to `activeFrom` in `AllowedTxInfo`, `AllowedTokenTransferInfo`, `CosignerInfo`, and related UI logic (`fiducia-app/src/App.tsx`, `fiducia-app/src/types.ts`). [[1]](diffhunk://#diff-994b961880b30fb5a53fee7411c39b5585f96c630350a02edfb3c7310071cc56L239-R269) [[2]](diffhunk://#diff-994b961880b30fb5a53fee7411c39b5585f96c630350a02edfb3c7310071cc56L601-R631) [[3]](diffhunk://#diff-994b961880b30fb5a53fee7411c39b5585f96c630350a02edfb3c7310071cc56L841-R866) [[4]](diffhunk://#diff-0ca419857a83516e525de706007d796a8ab7d023c59f9de09a980698ee5bc20dL54-R54) [[5]](diffhunk://#diff-0ca419857a83516e525de706007d796a8ab7d023c59f9de09a980698ee5bc20dL78-R78)

* **Contract Address Update:**
  - Updated the Fiducia contract addresses for Sepolia and Gnosis chains in `constants.ts`.

### Smart Contract Updates:

* **Mapping and Struct Changes:**
  - Replaced `maxAmount` with `amount` in the `TokenTransferInfo` struct and updated the `allowedTokenTransferInfos` mapping to use `token` and `recipient` as keys instead of a hashed identifier (`src/Fiducia.sol`). [[1]](diffhunk://#diff-cbe7ba085f9fc396dcf93b804a9471307d3bbca2ecbbc827f47539fa59d64ef6L32-R37) [[2]](diffhunk://#diff-cbe7ba085f9fc396dcf93b804a9471307d3bbca2ecbbc827f47539fa59d64ef6L71-R82)

* **Field Renaming:**
  - Renamed `allowedTimestamp` to `activeFrom` across mappings, structs, and events for consistency and clarity (`src/Fiducia.sol`). [[1]](diffhunk://#diff-cbe7ba085f9fc396dcf93b804a9471307d3bbca2ecbbc827f47539fa59d64ef6L242-R260) [[2]](diffhunk://#diff-cbe7ba085f9fc396dcf93b804a9471307d3bbca2ecbbc827f47539fa59d64ef6L611-R615)

* **Function Interface Updates:**
  - Updated function signatures and logic to reflect the changes in field names and mapping keys (`src/Fiducia.sol`). [[1]](diffhunk://#diff-cbe7ba085f9fc396dcf93b804a9471307d3bbca2ecbbc827f47539fa59d64ef6L394-R411) [[2]](diffhunk://#diff-5e35d7739d8d43b7ca47022aae13bc8de863f160184c974df1ad960a7a962c1cL58-R67) 

These changes enhance code readability, improve the user experience, and ensure consistency between the frontend and backend.