### PR TITLE
Cosigner Changes

### DIFF
--- a/fiducia-app/src/App.tsx
+++ b/fiducia-app/src/App.tsx
@@ -162,7 +162,7 @@ function App() {
             to: txInfo.to,
             selector: txInfo.selector == '0x00000000' ? '' : txInfo.selector,
             operation: txInfo.operation == 0 ? 'Call' : 'Delegate Call',
-            allowedTimestamp: timestampInfo * MILLISECONDS_IN_SECOND,
+            activeFrom: timestampInfo * MILLISECONDS_IN_SECOND,
           }
         })
       )
@@ -212,7 +212,7 @@ function App() {
       // Then, get amount & timestamp info using the token & recipient info
       const allowedTokenTxs = await Promise.all(
         tokenInfos.map(async tokenInfo => {
-          const result = await call(
+          const amountAndTimestamp = await call(
             sdk,
             fiduciaAddress,
             'allowedTokenTransferInfos',
@@ -223,11 +223,13 @@ function App() {
             ]
           )
 
+          const decimal = await call(sdk, tokenInfo.token, 'decimals', [])
+
           return {
             token: tokenInfo.token,
             recipient: tokenInfo.recipient,
-            amount: result.amount,
-            activeFrom: result.activeFrom * MILLISECONDS_IN_SECOND,
+            amount: amountAndTimestamp.amount / 10n ** decimal,
+            activeFrom: amountAndTimestamp.activeFrom * MILLISECONDS_IN_SECOND,
           }
         })
       )

--- a/fiducia-app/src/constants.ts
+++ b/fiducia-app/src/constants.ts
@@ -13,12 +13,12 @@ import { ethers } from 'ethers'
 
 /** Fiducia contract address on Sepolia testnet */
 export const FIDUCIA_ADDRESS_SEPOLIA = ethers.getAddress(
-  '0x016a4389ac2c9c2468f98f598e1129a697207312'
+  '0x4851a87b4ce998901f35b03f52b6954981e68245'
 )
 
 /** Fiducia contract address on Gnosis Chain */
 export const FIDUCIA_ADDRESS_GNOSIS = ethers.getAddress(
-  '0x016a4389ac2c9c2468f98f598e1129a697207312'
+  '0x4851a87b4ce998901f35b03f52b6954981e68245'
 )
 
 /** Safe MultiSendCallOnly contract address */

--- a/src/test/AppFiducia.sol
+++ b/src/test/AppFiducia.sol
@@ -115,19 +115,6 @@ contract AppFiducia is Fiducia {
     }
 
     /**
-     * @dev Decodes the cosigner signature from the provided signatures.
-     * @return The decoded cosigner signature.
-     * @dev This function is used to be compatible with the Varangian cosigner.
-     */
-    function _decodeCosignerSignature(bytes calldata signatures) internal pure override returns (bytes calldata) {
-        if (signatures.length < 66) {
-            return _emptyContext();
-        }
-
-        return signatures[signatures.length - 65:];
-    }
-
-    /**
      * @notice This function is called after the execution of a transaction to check if the guard is set up correctly.
      * @dev This function only checks the Tx Guard and not the Module Guard. This is done for v1.4.1 Wallet Interface compatibility.
      */


### PR DESCRIPTION
## TLDR
- Removed use of different cosigner signature encoding, as we now are using cosigner (Varangian) with the encoding scheme the same as our fiducia guard expects.
- Updated a minor naming inconsistency resulting in an invalid date.
- Deployed new contracts based on the signature encoding change.

## LLM Description
This pull request introduces several updates to improve functionality and maintainability in the Fiducia application. Key changes include renaming variables for clarity, adding token decimal handling, updating contract addresses, and removing an unused function from the smart contract. Below is a breakdown of the most important changes:

### Application Logic Updates:
* Renamed `allowedTimestamp` to `activeFrom` in transaction mapping for better clarity (`fiducia-app/src/App.tsx`).
* Updated logic to include token decimal handling when calculating token amounts, ensuring accurate representation (`fiducia-app/src/App.tsx`).

### Contract Address Updates:
* Updated Fiducia contract addresses for both Sepolia and Gnosis chains to new values (`fiducia-app/src/constants.ts`).

### Smart Contract Simplification:
* Removed the `_decodeCosignerSignature` function from the `AppFiducia` contract as it is no longer required, simplifying the codebase (`src/test/AppFiducia.sol`).