### PR TITLE
Banner & Footer Component

### DIFF
--- a/fiducia-app/src/App.tsx
+++ b/fiducia-app/src/App.tsx
@@ -39,6 +39,10 @@ import {
   isValidOperation,
 } from './utils/validation'
 import { useSafeConnection } from './hooks/useSafeConnection'
+import {
+  SafeResearchBanner,
+  SafeResearchFooter,
+} from './components/SafeResearch'
 
 const CONTRACT_INTERFACE = new ethers.Interface(CONTRACT_INTERFACE_ABI)
 
@@ -533,12 +537,7 @@ function App() {
 
   return (
     <>
-      <div className="card">
-        <Alert severity="warning">
-          This demo is an experimental beta release. Code is not audited. Use at
-          your own risk.
-        </Alert>
-      </div>
+      <SafeResearchBanner />
       <div>
         <a href="https://github.com/safe-research/fiducia" target="_blank">
           <img src={'./fiducia.svg'} className="logo" alt="Fiducia logo" />
@@ -1125,6 +1124,7 @@ function App() {
         )}
         {errorMessage ? <p className="error">{errorMessage}</p> : null}
       </div>
+      <SafeResearchFooter repo="fiducia" />
     </>
   )
 }

--- a/fiducia-app/src/components/SafeResearch.tsx
+++ b/fiducia-app/src/components/SafeResearch.tsx
@@ -1,0 +1,46 @@
+import { Alert, Link, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+
+export const CustomLink = ({
+  to,
+  children,
+}: {
+  to: string
+  children: ReactNode
+}) => {
+  return (
+    <Link
+      href={to}
+      target="_blank"
+      rel="noopener"
+      underline="none"
+      color="inherit"
+      sx={{ ':hover': { color: '#12ff80' } }}
+    >
+      {children}
+    </Link>
+  )
+}
+
+export const SafeResearchBanner = () => {
+  return (
+    <Alert severity="warning">
+      This demo is an experimental beta release. Code is not audited. Use at
+      your own risk.
+    </Alert>
+  )
+}
+
+export const SafeResearchFooter = ({ repo }: { repo: string }) => {
+  return (
+    <Typography>
+      <CustomLink to="https://github.com/safe-research">
+        Built by Safe Research
+      </CustomLink>
+      &nbsp;&hearts;&nbsp;
+      <CustomLink to={`https://github.com/safe-research/${repo}`}>
+        Source on GitHub
+      </CustomLink>
+    </Typography>
+  )
+}


### PR DESCRIPTION
This pull request refactors the display of the experimental beta warning and adds a footer to the app by introducing reusable components for banners and links. The main changes are the extraction of banner and footer UI into a new `SafeResearch` component, and their integration into the main app file.

**UI Component Refactoring:**

* Added `SafeResearchBanner` and `SafeResearchFooter` components to `fiducia-app/src/components/SafeResearch.tsx`, encapsulating the warning alert and footer links for reuse.
* Replaced the inline warning `Alert` in `fiducia-app/src/App.tsx` with the new `SafeResearchBanner` component for cleaner code and easier maintenance.

**Footer Enhancement:**

* Added `SafeResearchFooter` to the bottom of the app in `fiducia-app/src/App.tsx`, providing links to the Safe Research organization and the source repository.

**Code Organization:**

* Updated imports in `fiducia-app/src/App.tsx` to use the new components from `SafeResearch`.